### PR TITLE
Revamp homepage showcases and company info

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -73,9 +73,23 @@ nav {
 }
 
 .logo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  line-height: 1;
+}
+
+.logo-main {
   font-weight: 700;
   font-size: 1.4rem;
   letter-spacing: 0.08em;
+}
+
+.logo-sub {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.8);
+  letter-spacing: 0.04em;
+  font-weight: 500;
 }
 
 .nav-links {
@@ -316,6 +330,83 @@ nav {
   color: var(--primary-color);
   font-size: 0.75rem;
   font-weight: 600;
+}
+
+.showcase {
+  background: linear-gradient(135deg, #ffffff 0%, #f4f0ff 100%);
+  position: relative;
+}
+
+.showcase::before {
+  content: '';
+  position: absolute;
+  inset: 24px;
+  border-radius: 32px;
+  background: rgba(255, 255, 255, 0.6);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.showcase > * {
+  position: relative;
+  z-index: 1;
+}
+
+.showcase .section-header {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.showcase .section-header h2 {
+  font-size: 2.2rem;
+}
+
+.showcase-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.showcase-card {
+  background: #fff;
+  border-radius: 26px;
+  box-shadow: 0 24px 46px rgba(41, 27, 102, 0.12);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.showcase-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 32px 60px rgba(41, 27, 102, 0.18);
+}
+
+.showcase-card-image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+}
+
+.showcase-card-body {
+  padding: 26px 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  height: 100%;
+}
+
+.showcase-card-body h3 {
+  margin: 0;
+  font-size: 1.3rem;
+  text-align: center;
+}
+
+.showcase-card-body p {
+  margin: 0;
+  color: var(--muted-text);
+  line-height: 1.7;
 }
 
 .footer {
@@ -1194,6 +1285,14 @@ textarea:focus {
 
   .section {
     padding: 60px 24px;
+  }
+
+  .logo {
+    gap: 2px;
+  }
+
+  .showcase::before {
+    inset: 16px;
   }
 
   .dashboard {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,10 @@
   <body>
     <header class="scroll-reveal">
       <nav>
-        <div class="logo">DUODUO SYNC</div>
+        <div class="logo">
+          <span class="logo-main">DUODUO SYNC</span>
+          <span class="logo-sub">天津天开多多合作资源有限公司</span>
+        </div>
         <div class="nav-links">
           <a href="#industries">行业场景</a>
           <a href="#solutions">合作方案</a>
@@ -60,7 +63,7 @@
         <div class="gallery-slider" role="region" aria-label="活动图片轮播">
           <div class="slider-track" id="galleryTrack">
             <figure class="slide active">
-              <img src="https://images.unsplash.com/photo-1503424886300-4f83c2b4b8f0?auto=format&fit=crop&w=1200&q=80" alt="产业合作圆桌会议现场" />
+              <img src="https://images.unsplash.com/photo-1580894908361-967195033215?auto=format&fit=crop&w=1200&q=80" alt="产业合作圆桌会议现场" />
               <figcaption>产业合作圆桌 · 与会嘉宾深度交流</figcaption>
             </figure>
             <figure class="slide">
@@ -151,76 +154,153 @@
       </div>
     </section>
 
-    <section class="section scroll-reveal" id="solutions">
+    <section class="section scroll-reveal showcase" id="solutions">
       <div class="section-header">
         <h2>协同方案矩阵</h2>
         <p>
           基于平台内沉淀的资源画像与供应能力，提供一站式合作方案，支持项目孵化、商业化与落地。
         </p>
       </div>
-      <div class="grid">
-        <div class="card">
-          <h3>资源市场</h3>
-          <p>分级标注资源的领导层级、行业方向、成功案例与回款表现，为二次销售提供可视化评估。</p>
-        </div>
-        <div class="card">
-          <h3>产品服务市场</h3>
-          <p>沉淀会员单位产品与上下游能力，实现供应商池画像化管理，支持快速筛选与对接。</p>
-        </div>
-        <div class="card">
-          <h3>活动会议中枢</h3>
-          <p>活动发起、审批与执行在线协同，形成全过程档案沉淀与复盘，保障合作效率。</p>
-        </div>
-        <div class="card">
-          <h3>智能通知与触达</h3>
-          <p>平台消息同步推送至微信公众平台，实现实时提醒与直接沟通。</p>
-        </div>
+      <div class="showcase-grid">
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80"
+            alt="资源市场协同场景"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>资源市场</h3>
+            <p>分级标注资源的领导层级、行业方向、成功案例与回款表现，为二次销售提供可视化评估。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
+            alt="产品服务市场协同"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>产品服务市场</h3>
+            <p>沉淀会员单位产品与上下游能力，实现供应商池画像化管理，支持快速筛选与对接。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1511578314322-379afb476865?auto=format&fit=crop&w=1200&q=80"
+            alt="活动会议协同中心"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>活动会议中枢</h3>
+            <p>活动发起、审批与执行在线协同，形成全过程档案沉淀与复盘，保障合作效率。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1200&q=80"
+            alt="智能通知触达示意"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>智能通知与触达</h3>
+            <p>平台消息同步推送至微信公众平台，实现实时提醒与直接沟通。</p>
+          </div>
+        </article>
       </div>
     </section>
 
-    <section class="section scroll-reveal" id="cases">
+    <section class="section scroll-reveal showcase" id="cases">
       <div class="section-header">
         <h2>精选合作案例</h2>
         <p>真实记录平台合作成果，为会员展示资源转化效率与业务增长路径。</p>
       </div>
-      <div class="grid">
-        <div class="card">
-          <h3>创新药企全国渠道加速</h3>
-          <p>整合 18 个省市政府与医院资源，三个月内完成 6 个项目落地。</p>
-        </div>
-        <div class="card">
-          <h3>制造企业供应链协同</h3>
-          <p>对接 32 家供应商，建立柔性生产联盟，订单转化率提升 45%。</p>
-        </div>
-        <div class="card">
-          <h3>园区招商项目撮合</h3>
-          <p>协助园区与头部企业达成战略合作，并实现落地后的产业基金跟投。</p>
-        </div>
+      <div class="showcase-grid">
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+            alt="创新药企合作案例"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>创新药企全国渠道加速</h3>
+            <p>整合 18 个省市政府与医院资源，三个月内完成 6 个项目落地。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
+            alt="制造企业供应链协同案例"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>制造企业供应链协同</h3>
+            <p>对接 32 家供应商，建立柔性生产联盟，订单转化率提升 45%。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1521737451536-00a86f630f80?auto=format&fit=crop&w=1200&q=80"
+            alt="园区招商项目合作案例"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>园区招商项目撮合</h3>
+            <p>协助园区与头部企业达成战略合作，并实现落地后的产业基金跟投。</p>
+          </div>
+        </article>
       </div>
     </section>
 
-    <section class="section scroll-reveal" id="ecosystem">
+    <section class="section scroll-reveal showcase" id="ecosystem">
       <div class="section-header">
         <h2>平台服务矩阵</h2>
         <p>与各类专业机构、咨询伙伴、行业协会共同打造共赢生态，为会员提供全流程支撑。</p>
       </div>
-      <div class="grid">
-        <div class="card">
-          <h3>战略咨询合作</h3>
-          <p>参考国际咨询经验，提供从战略规划到实施落地的综合服务。</p>
-        </div>
-        <div class="card">
-          <h3>专家智库网络</h3>
-          <p>聚合行业专家、行业协会资源，实现经验分享与联合创新。</p>
-        </div>
-        <div class="card">
-          <h3>数字化工具支撑</h3>
-          <p>平台内置多种协同与分析工具，支持数据驱动的决策过程。</p>
-        </div>
-        <div class="card">
-          <h3>品牌曝光权益</h3>
-          <p>会员可通过业绩交易提交提升曝光度，强化品牌影响力与合作机会。</p>
-        </div>
+      <div class="showcase-grid">
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1200&q=80"
+            alt="战略咨询合作场景"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>战略咨询合作</h3>
+            <p>参考国际咨询经验，提供从战略规划到实施落地的综合服务。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+            alt="专家智库网络交流"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>专家智库网络</h3>
+            <p>聚合行业专家、行业协会资源，实现经验分享与联合创新。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1200&q=80"
+            alt="数字化工具支撑展示"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>数字化工具支撑</h3>
+            <p>平台内置多种协同与分析工具，支持数据驱动的决策过程。</p>
+          </div>
+        </article>
+        <article class="showcase-card">
+          <img
+            src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=1200&q=80"
+            alt="品牌曝光权益展示"
+            class="showcase-card-image"
+          />
+          <div class="showcase-card-body">
+            <h3>品牌曝光权益</h3>
+            <p>会员可通过业绩交易提交提升曝光度，强化品牌影响力与合作机会。</p>
+          </div>
+        </article>
       </div>
     </section>
 
@@ -233,7 +313,7 @@
         <div>
           <h4>联系我们</h4>
           <p>邮箱: contact@duoduoplatform.com</p>
-          <p>地址: 上海市浦东新区张江高科技园区</p>
+          <p>地址: 天津市科技广场天开园</p>
         </div>
         <div>
           <h4>合作咨询</h4>


### PR DESCRIPTION
## Summary
- add a Chinese company name under the DUODUO SYNC logo and refresh the hero gallery image to avoid 404s
- restyle the solution, case, and service matrices with richer showcase cards and supporting CSS so the sections stand apart visually
- update the contact address to the Tianjin TianKai Park location

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9f312d68883208deb7acb01ef8fab