### PR TITLE
Fix homepage image 404s by bundling local assets

### DIFF
--- a/assets/images/cases-manufacturing.svg
+++ b/assets/images/cases-manufacturing.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="casesManufacturingGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#casesManufacturingGradient)" />
+  <g fill="#ccfbf1" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">MANUFACTURING ALLIANCE</text>
+    <text x="200" y="280" font-size="42">供应链协同</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">柔性生产联盟</text>
+  </g>
+  <g stroke="#99f6e4" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 480 Q 420 340 680 420 T 1000 380" />
+    <path d="M240 560 Q 520 400 780 480 T 1020 420" opacity="0.6" />
+  </g>
+  <g transform="translate(340 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.35)" stroke-width="8" />
+    <g fill="#ccfbf1">
+      <circle cx="140" cy="120" r="36" />
+      <circle cx="260" cy="200" r="44" opacity="0.8" />
+      <circle cx="380" cy="140" r="32" opacity="0.6" />
+    </g>
+  </g>
+</svg>

--- a/assets/images/cases-park.svg
+++ b/assets/images/cases-park.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="casesParkGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7c3aed" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#casesParkGradient)" />
+  <g fill="#ede9fe" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">PARK ALLIANCE</text>
+    <text x="200" y="280" font-size="42">园区招商项目撮合</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">战略合作落地</text>
+  </g>
+  <g stroke="#ddd6fe" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 480 Q 460 360 720 440 T 1020 380" />
+    <path d="M240 560 Q 520 420 780 500 T 1040 420" opacity="0.6" />
+  </g>
+  <g transform="translate(340 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.2)" stroke="rgba(255,255,255,0.35)" stroke-width="8" />
+    <g fill="#ede9fe">
+      <circle cx="140" cy="120" r="32" />
+      <circle cx="260" cy="200" r="42" opacity="0.8" />
+      <circle cx="380" cy="140" r="30" opacity="0.6" />
+    </g>
+  </g>
+</svg>

--- a/assets/images/cases-pharma.svg
+++ b/assets/images/cases-pharma.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="casesPharmaGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#60a5fa" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#casesPharmaGradient)" />
+  <g fill="#dbeafe" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">PHARMA CASE</text>
+    <text x="200" y="280" font-size="42">创新药企渠道加速</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">多省市医院资源</text>
+  </g>
+  <g stroke="#bfdbfe" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M220 480 Q 420 360 640 420 T 980 360" />
+    <path d="M260 560 Q 500 420 740 480 T 1000 420" opacity="0.6" />
+  </g>
+  <g transform="translate(340 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.3)" stroke-width="8" />
+    <g fill="#dbeafe">
+      <circle cx="140" cy="120" r="34" />
+      <circle cx="260" cy="200" r="44" opacity="0.8" />
+      <circle cx="380" cy="140" r="30" opacity="0.6" />
+    </g>
+  </g>
+</svg>

--- a/assets/images/ecosystem-brand.svg
+++ b/assets/images/ecosystem-brand.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="ecosystemBrandGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ea580c" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#ecosystemBrandGradient)" />
+  <g fill="#fef08a" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">BRAND EXPOSURE</text>
+    <text x="200" y="280" font-size="42">品牌曝光权益</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">业绩交易提升影响力</text>
+  </g>
+  <g transform="translate(320 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.38)" stroke-width="8" />
+    <g fill="#fef9c3">
+      <circle cx="140" cy="120" r="30" />
+      <circle cx="260" cy="200" r="38" opacity="0.8" />
+      <circle cx="380" cy="140" r="28" opacity="0.6" />
+    </g>
+  </g>
+  <g stroke="#fde68a" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 500 Q 420 380 680 440 T 1000 380" />
+    <path d="M240 580 Q 520 440 780 500 T 1020 440" opacity="0.6" />
+  </g>
+</svg>

--- a/assets/images/ecosystem-consulting.svg
+++ b/assets/images/ecosystem-consulting.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="ecosystemConsultingGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#9333ea" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#ecosystemConsultingGradient)" />
+  <g fill="#e0e7ff" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">STRATEGY PARTNERS</text>
+    <text x="200" y="280" font-size="42">战略咨询合作</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">从规划到落地</text>
+  </g>
+  <g transform="translate(320 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.16)" stroke="rgba(255,255,255,0.35)" stroke-width="8" />
+    <g fill="#e0e7ff">
+      <circle cx="140" cy="120" r="34" />
+      <circle cx="260" cy="200" r="40" opacity="0.8" />
+      <circle cx="380" cy="140" r="30" opacity="0.6" />
+    </g>
+  </g>
+  <g stroke="#c7d2fe" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 500 Q 420 380 680 440 T 1000 380" />
+    <path d="M240 580 Q 520 440 780 500 T 1020 440" opacity="0.6" />
+  </g>
+</svg>

--- a/assets/images/ecosystem-digital.svg
+++ b/assets/images/ecosystem-digital.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="ecosystemDigitalGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#ecosystemDigitalGradient)" />
+  <g fill="#bfdbfe" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">DIGITAL TOOLBOX</text>
+    <text x="200" y="280" font-size="42">数字化工具支撑</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">数据驱动决策</text>
+  </g>
+  <g transform="translate(320 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.14)" stroke="rgba(255,255,255,0.28)" stroke-width="8" />
+    <g fill="#bfdbfe">
+      <circle cx="120" cy="120" r="30" />
+      <circle cx="240" cy="200" r="40" opacity="0.8" />
+      <circle cx="360" cy="140" r="32" opacity="0.6" />
+    </g>
+  </g>
+  <g stroke="#bfdbfe" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 500 Q 440 360 680 420 T 1000 360" />
+    <path d="M240 580 Q 520 440 780 500 T 1020 440" opacity="0.6" />
+  </g>
+</svg>

--- a/assets/images/ecosystem-expert.svg
+++ b/assets/images/ecosystem-expert.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="ecosystemExpertGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6d28d9" />
+      <stop offset="100%" stop-color="#f472b6" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#ecosystemExpertGradient)" />
+  <g fill="#fae8ff" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">EXPERT NETWORK</text>
+    <text x="200" y="280" font-size="42">专家智库网络</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">经验分享与创新</text>
+  </g>
+  <g transform="translate(320 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.35)" stroke-width="8" />
+    <g fill="#fae8ff">
+      <circle cx="140" cy="120" r="32" />
+      <circle cx="260" cy="200" r="40" opacity="0.8" />
+      <circle cx="380" cy="140" r="30" opacity="0.6" />
+    </g>
+  </g>
+  <g stroke="#f5d0fe" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 500 Q 420 360 680 420 T 1000 360" />
+    <path d="M240 580 Q 520 440 780 500 T 1020 440" opacity="0.6" />
+  </g>
+</svg>

--- a/assets/images/header-bg.svg
+++ b/assets/images/header-bg.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4e2d8e" />
+      <stop offset="100%" stop-color="#4a90e2" />
+    </linearGradient>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.25)" />
+      <stop offset="50%" stop-color="rgba(255,255,255,0.45)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0.1)" />
+    </linearGradient>
+    <radialGradient id="spot" cx="75%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.35)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad)" />
+  <rect x="-100" y="-150" width="1800" height="450" fill="url(#glow)" transform="rotate(12 800 450)" opacity="0.7" />
+  <circle cx="1100" cy="200" r="400" fill="url(#spot)" />
+  <g fill="rgba(255,255,255,0.2)" font-family="'Segoe UI', Tahoma, sans-serif" font-weight="600" font-size="56">
+    <text x="160" y="320">COLLABORATION</text>
+    <text x="360" y="520" font-size="80" opacity="0.35">DUODUO SYNC</text>
+    <text x="980" y="720" font-size="44" opacity="0.25">INDUSTRY ALLIANCE</text>
+  </g>
+  <g stroke="rgba(255,255,255,0.28)" stroke-width="4" fill="none">
+    <path d="M200 620 C 500 520 780 680 1120 560" opacity="0.4" />
+    <path d="M260 760 C 620 720 960 860 1380 720" opacity="0.3" />
+    <path d="M140 200 C 480 140 860 280 1320 160" opacity="0.2" />
+  </g>
+</svg>

--- a/assets/images/hero-activity.svg
+++ b/assets/images/hero-activity.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#53389e" />
+      <stop offset="100%" stop-color="#8b5cf6" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#gradient)" />
+  <g opacity="0.4" fill="none" stroke="#c4b5fd" stroke-width="4">
+    <circle cx="340" cy="260" r="120" />
+    <circle cx="820" cy="540" r="180" />
+    <path d="M220 600 Q 600 460 980 620" />
+  </g>
+  <g fill="#ede9fe" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="140" y="150" font-size="54" font-weight="700">ACTIVITY SNAPSHOT</text>
+    <text x="160" y="240" font-size="40">圆桌共创 · 策略会谈</text>
+    <text x="160" y="310" font-size="30" opacity="0.8">沉浸式活动瞬间</text>
+  </g>
+  <rect x="420" y="190" width="480" height="320" rx="32" ry="32" fill="rgba(255,255,255,0.12)" stroke="rgba(255,255,255,0.25)" stroke-width="6" />
+  <g transform="translate(450 240)" fill="#f5f3ff">
+    <circle cx="40" cy="40" r="26" />
+    <circle cx="160" cy="100" r="34" opacity="0.7" />
+    <circle cx="320" cy="70" r="28" opacity="0.5" />
+    <circle cx="220" cy="200" r="46" opacity="0.4" />
+  </g>
+</svg>

--- a/assets/images/hero-signing.svg
+++ b/assets/images/hero-signing.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="heroSigningGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ec4899" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#heroSigningGradient)" />
+  <g fill="rgba(255,255,255,0.18)">
+    <rect x="160" y="200" width="880" height="420" rx="52" />
+    <rect x="220" y="260" width="760" height="300" rx="36" fill="rgba(255,255,255,0.22)" />
+  </g>
+  <g stroke="#fee2e2" stroke-width="12" stroke-linecap="round" fill="none">
+    <path d="M300 420 Q 460 360 620 440 T 900 420" />
+    <path d="M320 480 Q 520 420 720 500 T 900 500" opacity="0.6" />
+  </g>
+  <g fill="#fff1f2" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="260" y="240" font-size="60" font-weight="700">SIGNING CEREMONY</text>
+    <text x="260" y="310" font-size="40">跨产业合作签约</text>
+    <text x="260" y="360" font-size="32" opacity="0.85">资源撮合快速落地</text>
+  </g>
+  <g transform="translate(320 380)" fill="#fff1f2">
+    <circle cx="60" cy="60" r="26" opacity="0.9" />
+    <circle cx="160" cy="120" r="34" opacity="0.7" />
+    <circle cx="300" cy="80" r="28" opacity="0.6" />
+    <circle cx="440" cy="140" r="42" opacity="0.5" />
+  </g>
+</svg>

--- a/assets/images/hero-visual.svg
+++ b/assets/images/hero-visual.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="heroVisualGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#heroVisualGradient)" />
+  <g fill="rgba(255,255,255,0.2)">
+    <polygon points="140,180 1060,120 1000,700 120,640" />
+    <polygon points="220,260 960,220 900,620 200,580" fill="rgba(255,255,255,0.25)" />
+  </g>
+  <g fill="#ecfeff" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="180" y="190" font-size="64" font-weight="700">EVENT VISION</text>
+    <text x="180" y="260" font-size="42">智慧园区招商会</text>
+    <text x="180" y="320" font-size="32" opacity="0.85">数字化展示与互动体验</text>
+  </g>
+  <g transform="translate(320 360)" stroke="#ecfeff" stroke-width="6" fill="none" stroke-linecap="round">
+    <path d="M0 120 Q 120 -20 240 80 T 480 60" />
+    <path d="M40 200 Q 200 40 360 200 T 520 180" opacity="0.6" />
+  </g>
+  <g transform="translate(360 420)" fill="#ecfeff">
+    <circle cx="60" cy="60" r="26" />
+    <circle cx="180" cy="120" r="32" opacity="0.8" />
+    <circle cx="320" cy="80" r="40" opacity="0.6" />
+    <circle cx="460" cy="140" r="28" opacity="0.5" />
+  </g>
+</svg>

--- a/assets/images/solutions-event.svg
+++ b/assets/images/solutions-event.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="solutionsEventGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#4338ca" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#solutionsEventGradient)" />
+  <g fill="#eef2ff" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">EVENT HUB</text>
+    <text x="200" y="280" font-size="42">活动会议中枢</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">全流程档案沉淀</text>
+  </g>
+  <g transform="translate(320 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.16)" stroke="rgba(255,255,255,0.35)" stroke-width="8" />
+    <g fill="#e0e7ff">
+      <circle cx="140" cy="120" r="32" />
+      <circle cx="260" cy="200" r="40" opacity="0.8" />
+      <circle cx="380" cy="140" r="34" opacity="0.6" />
+    </g>
+  </g>
+  <g stroke="#e0e7ff" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.7">
+    <path d="M160 520 Q 360 400 560 500 T 960 420" />
+    <path d="M180 600 Q 420 460 660 560 T 980 500" opacity="0.6" />
+  </g>
+</svg>

--- a/assets/images/solutions-notification.svg
+++ b/assets/images/solutions-notification.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="solutionsNotificationGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#fb7185" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#solutionsNotificationGradient)" />
+  <g fill="#fff7ed" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">NOTIFICATION HUB</text>
+    <text x="200" y="280" font-size="42">智能通知与触达</text>
+    <text x="200" y="330" font-size="32" opacity="0.85">实时提醒与沟通</text>
+  </g>
+  <g stroke="#fed7aa" stroke-width="8" stroke-linecap="round" fill="none">
+    <path d="M220 520 Q 440 420 660 520 T 980 440" />
+    <path d="M260 600 Q 520 480 780 560 T 1000 500" opacity="0.6" />
+  </g>
+  <g transform="translate(320 320)">
+    <rect width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.2)" stroke="rgba(255,255,255,0.38)" stroke-width="8" />
+    <g fill="#fff7ed">
+      <circle cx="140" cy="120" r="30" />
+      <circle cx="260" cy="200" r="38" opacity="0.8" />
+      <circle cx="380" cy="140" r="28" opacity="0.6" />
+      <circle cx="440" cy="220" r="34" opacity="0.5" />
+    </g>
+  </g>
+</svg>

--- a/assets/images/solutions-product.svg
+++ b/assets/images/solutions-product.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="solutionsProductGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#34d399" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#solutionsProductGradient)" />
+  <g fill="rgba(255,255,255,0.18)">
+    <rect x="160" y="220" width="880" height="360" rx="48" />
+    <rect x="220" y="280" width="360" height="240" rx="32" />
+    <rect x="620" y="280" width="320" height="240" rx="32" opacity="0.7" />
+  </g>
+  <g fill="#ecfdf5" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="180" y="200" font-size="62" font-weight="700">PRODUCT SERVICES</text>
+    <text x="180" y="260" font-size="40">产品服务市场</text>
+    <text x="180" y="310" font-size="32" opacity="0.8">供应链画像管理</text>
+  </g>
+  <g transform="translate(260 340)" stroke="#d1fae5" stroke-width="8" stroke-linecap="round" fill="none">
+    <path d="M0 120 Q 140 40 280 120 T 520 100" />
+    <path d="M40 200 Q 180 120 320 200 T 500 180" opacity="0.6" />
+  </g>
+  <g transform="translate(320 360)" fill="#ecfdf5">
+    <circle cx="60" cy="80" r="28" />
+    <circle cx="180" cy="140" r="36" opacity="0.8" />
+    <circle cx="300" cy="100" r="32" opacity="0.6" />
+    <circle cx="420" cy="160" r="24" opacity="0.5" />
+  </g>
+</svg>

--- a/assets/images/solutions-resource.svg
+++ b/assets/images/solutions-resource.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="solutionsResourceGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a8a" />
+      <stop offset="100%" stop-color="#3b82f6" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#solutionsResourceGradient)" />
+  <g stroke="#bfdbfe" stroke-width="10" stroke-linecap="round" fill="none">
+    <path d="M200 500 Q 420 360 620 460 T 1000 360" />
+    <path d="M240 580 Q 520 420 820 520 T 980 480" opacity="0.6" />
+  </g>
+  <g fill="#dbeafe" font-family="'Segoe UI', Tahoma, sans-serif">
+    <text x="200" y="220" font-size="64" font-weight="700">RESOURCE MARKET</text>
+    <text x="200" y="290" font-size="42">资源市场协同场景</text>
+    <text x="200" y="340" font-size="32" opacity="0.8">可视化评估与撮合</text>
+  </g>
+  <g transform="translate(360 320)">
+    <rect x="0" y="0" width="520" height="320" rx="36" ry="36" fill="rgba(255,255,255,0.18)" stroke="rgba(255,255,255,0.3)" stroke-width="8" />
+    <g fill="#e0f2fe">
+      <circle cx="120" cy="120" r="34" />
+      <circle cx="240" cy="200" r="42" opacity="0.8" />
+      <circle cx="380" cy="140" r="30" opacity="0.6" />
+    </g>
+  </g>
+</svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -49,7 +49,7 @@ a {
 
 header {
   background: linear-gradient(135deg, rgba(78, 45, 142, 0.95), rgba(74, 144, 226, 0.9)),
-    url('https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1600&q=80') center/cover;
+    url('images/header-bg.svg') center/cover;
   color: #fff;
   padding: 24px 0 120px;
   position: relative;

--- a/index.html
+++ b/index.html
@@ -63,15 +63,15 @@
         <div class="gallery-slider" role="region" aria-label="活动图片轮播">
           <div class="slider-track" id="galleryTrack">
             <figure class="slide active">
-              <img src="https://images.unsplash.com/photo-1580894908361-967195033215?auto=format&fit=crop&w=1200&q=80" alt="产业合作圆桌会议现场" />
+              <img src="assets/images/hero-activity.svg" alt="产业合作圆桌会议现场" loading="lazy" />
               <figcaption>产业合作圆桌 · 与会嘉宾深度交流</figcaption>
             </figure>
             <figure class="slide">
-              <img src="https://images.unsplash.com/photo-1531058020387-3be344556be6?auto=format&fit=crop&w=1200&q=80" alt="活动主视觉展示" />
+              <img src="assets/images/hero-visual.svg" alt="活动主视觉展示" loading="lazy" />
               <figcaption>智慧园区招商会 · 数字化展示与互动体验</figcaption>
             </figure>
             <figure class="slide">
-              <img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80" alt="合作签约仪式" />
+              <img src="assets/images/hero-signing.svg" alt="合作签约仪式" loading="lazy" />
               <figcaption>跨产业合作签约 · 资源撮合快速落地</figcaption>
             </figure>
           </div>
@@ -163,44 +163,28 @@
       </div>
       <div class="showcase-grid">
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80"
-            alt="资源市场协同场景"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/solutions-resource.svg" alt="资源市场协同场景" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>资源市场</h3>
             <p>分级标注资源的领导层级、行业方向、成功案例与回款表现，为二次销售提供可视化评估。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80"
-            alt="产品服务市场协同"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/solutions-product.svg" alt="产品服务市场协同" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>产品服务市场</h3>
             <p>沉淀会员单位产品与上下游能力，实现供应商池画像化管理，支持快速筛选与对接。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1511578314322-379afb476865?auto=format&fit=crop&w=1200&q=80"
-            alt="活动会议协同中心"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/solutions-event.svg" alt="活动会议协同中心" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>活动会议中枢</h3>
             <p>活动发起、审批与执行在线协同，形成全过程档案沉淀与复盘，保障合作效率。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1200&q=80"
-            alt="智能通知触达示意"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/solutions-notification.svg" alt="智能通知触达示意" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>智能通知与触达</h3>
             <p>平台消息同步推送至微信公众平台，实现实时提醒与直接沟通。</p>
@@ -216,33 +200,21 @@
       </div>
       <div class="showcase-grid">
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
-            alt="创新药企合作案例"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/cases-pharma.svg" alt="创新药企合作案例" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>创新药企全国渠道加速</h3>
             <p>整合 18 个省市政府与医院资源，三个月内完成 6 个项目落地。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80"
-            alt="制造企业供应链协同案例"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/cases-manufacturing.svg" alt="制造企业供应链协同案例" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>制造企业供应链协同</h3>
             <p>对接 32 家供应商，建立柔性生产联盟，订单转化率提升 45%。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1521737451536-00a86f630f80?auto=format&fit=crop&w=1200&q=80"
-            alt="园区招商项目合作案例"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/cases-park.svg" alt="园区招商项目合作案例" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>园区招商项目撮合</h3>
             <p>协助园区与头部企业达成战略合作，并实现落地后的产业基金跟投。</p>
@@ -258,44 +230,28 @@
       </div>
       <div class="showcase-grid">
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&w=1200&q=80"
-            alt="战略咨询合作场景"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/ecosystem-consulting.svg" alt="战略咨询合作场景" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>战略咨询合作</h3>
             <p>参考国际咨询经验，提供从战略规划到实施落地的综合服务。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
-            alt="专家智库网络交流"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/ecosystem-expert.svg" alt="专家智库网络交流" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>专家智库网络</h3>
             <p>聚合行业专家、行业协会资源，实现经验分享与联合创新。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1519389950473-47ba0277781c?auto=format&fit=crop&w=1200&q=80"
-            alt="数字化工具支撑展示"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/ecosystem-digital.svg" alt="数字化工具支撑展示" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>数字化工具支撑</h3>
             <p>平台内置多种协同与分析工具，支持数据驱动的决策过程。</p>
           </div>
         </article>
         <article class="showcase-card">
-          <img
-            src="https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&w=1200&q=80"
-            alt="品牌曝光权益展示"
-            class="showcase-card-image"
-          />
+          <img src="assets/images/ecosystem-brand.svg" alt="品牌曝光权益展示" class="showcase-card-image" loading="lazy" />
           <div class="showcase-card-body">
             <h3>品牌曝光权益</h3>
             <p>会员可通过业绩交易提交提升曝光度，强化品牌影响力与合作机会。</p>


### PR DESCRIPTION
## Summary
- replace homepage gallery, showcase, and ecosystem imagery with bundled SVG assets to avoid external 404s
- update the header background to use the new local artwork so the hero section no longer depends on remote images

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da04dcfa348320a5a37097577528ba