### PR TITLE
feat: add mobile sidebar toggle and user menu dropdown

### DIFF
--- a/assets/dashboard.js
+++ b/assets/dashboard.js
@@ -3,6 +3,82 @@
   const messagePanel = document.getElementById('messagePanel');
   const userToggle = document.getElementById('userToggle');
   const userMenu = document.getElementById('userMenu');
+  const menuToggle = document.getElementById('menuToggle');
+  const sidebarNav = document.getElementById('sidebarNav');
+  const sidebarBackdrop = document.getElementById('sidebarBackdrop');
+  const mobileMediaQuery = window.matchMedia('(max-width: 900px)');
+
+  function setSidebarVisibility(isVisible) {
+    if (!sidebarNav) return;
+    sidebarNav.classList.toggle('open', isVisible);
+    if (menuToggle) {
+      menuToggle.setAttribute('aria-expanded', isVisible.toString());
+    }
+    if (sidebarBackdrop) {
+      if (isVisible) {
+        sidebarBackdrop.hidden = false;
+      } else {
+        sidebarBackdrop.hidden = true;
+      }
+    }
+    document.body.classList.toggle('menu-open', isVisible);
+  }
+
+  function closeSidebar({ focusToggle = false } = {}) {
+    if (!sidebarNav) return;
+    setSidebarVisibility(false);
+    if (focusToggle && menuToggle && mobileMediaQuery.matches) {
+      menuToggle.focus();
+    }
+  }
+
+  function openSidebar() {
+    if (!sidebarNav) return;
+    setSidebarVisibility(true);
+  }
+
+  function resetSidebarForDesktop() {
+    if (!sidebarNav) return;
+    if (!mobileMediaQuery.matches) {
+      closeSidebar();
+    }
+  }
+
+  if (menuToggle && sidebarNav) {
+    menuToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const willOpen = !sidebarNav.classList.contains('open');
+      if (willOpen) {
+        openSidebar();
+        closeMessagePanel();
+        closeUserMenu();
+      } else {
+        closeSidebar();
+      }
+    });
+  }
+
+  if (sidebarBackdrop) {
+    sidebarBackdrop.addEventListener('click', () => closeSidebar({ focusToggle: true }));
+  }
+
+  if (sidebarNav) {
+    sidebarNav.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        if (mobileMediaQuery.matches) {
+          closeSidebar();
+        }
+      });
+    });
+  }
+
+  if (mobileMediaQuery.addEventListener) {
+    mobileMediaQuery.addEventListener('change', resetSidebarForDesktop);
+  } else if (mobileMediaQuery.addListener) {
+    mobileMediaQuery.addListener(resetSidebarForDesktop);
+  }
+
+  resetSidebarForDesktop();
 
   function closeMessagePanel() {
     if (messagePanel) {
@@ -59,6 +135,20 @@
       if (!userMenu.contains(event.target) && !userToggle.contains(event.target)) {
         closeUserMenu();
       }
+    }
+
+    if (sidebarNav && menuToggle && sidebarNav.classList.contains('open')) {
+      if (!sidebarNav.contains(event.target) && !menuToggle.contains(event.target)) {
+        closeSidebar();
+      }
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeMessagePanel();
+      closeUserMenu();
+      closeSidebar({ focusToggle: true });
     }
   });
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -459,6 +459,10 @@ nav {
   align-self: start;
 }
 
+.sidebar.open {
+  transform: translateX(0);
+}
+
 .sidebar h3 {
   margin: 0 0 8px;
 }
@@ -475,6 +479,22 @@ nav {
 .sidebar a:hover {
   background: var(--secondary-color);
   color: var(--primary-color);
+}
+
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(23, 25, 45, 0.38);
+  backdrop-filter: blur(2px);
+  z-index: 65;
+}
+
+.sidebar-backdrop[hidden] {
+  display: none !important;
+}
+
+body.menu-open {
+  overflow: hidden;
 }
 
 .main-column {
@@ -523,6 +543,34 @@ nav {
   display: flex;
   align-items: center;
   gap: 16px;
+}
+
+.menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(71, 51, 168, 0.25);
+  background: #fff;
+  color: #3a2a8c;
+  font-size: 1.25rem;
+  cursor: pointer;
+  margin-right: 12px;
+  box-shadow: 0 12px 28px rgba(34, 23, 86, 0.12);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.menu-toggle:hover {
+  background: var(--secondary-color);
+  color: var(--primary-color);
+  transform: translateY(-2px);
+}
+
+.menu-toggle:focus-visible {
+  outline: 2px solid rgba(83, 68, 180, 0.4);
+  outline-offset: 4px;
 }
 
 .icon-button {
@@ -1297,23 +1345,86 @@ textarea:focus {
 
   .dashboard {
     grid-template-columns: 1fr;
-    padding: 32px 24px;
+    padding: 24px 20px 32px;
+    position: relative;
   }
 
   .sidebar {
-    flex-direction: row;
-    overflow-x: auto;
-    position: static;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 280px;
+    max-width: 78vw;
+    transform: translateX(-110%);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    border-radius: 0 20px 20px 0;
+    box-shadow: 0 24px 48px rgba(23, 25, 45, 0.18);
+    padding: 88px 24px 32px;
+    z-index: 80;
+    overflow-y: auto;
+  }
+
+  .sidebar h3 {
+    margin-top: 0;
+  }
+
+  .sidebar a {
+    padding: 14px 20px;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
   }
 
   .topbar {
-    position: static;
+    padding: 16px 20px;
+    position: sticky;
+    top: 0;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  .topbar-left {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    flex: 1 1 100%;
+  }
+
+  .topbar-subtitle {
+    flex-basis: 100%;
+    font-size: 0.82rem;
+  }
+
+  .topbar-title {
+    font-size: 1.1rem;
+  }
+
+  .topbar-actions {
+    flex: 1 1 100%;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .icon-button,
+  .avatar {
+    width: 36px;
+    height: 36px;
   }
 
   .gallery-content,
   .member-summary,
   .performance-grid {
     grid-template-columns: 1fr;
+  }
+
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .content-card {
+    padding: 24px;
   }
 
   .drawer {

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,6 +9,16 @@
   <body>
     <header class="topbar">
       <div class="topbar-left">
+        <button
+          class="menu-toggle"
+          id="menuToggle"
+          type="button"
+          aria-label="展开菜单"
+          aria-controls="sidebarNav"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
         <span class="topbar-title">会员工作台</span>
         <span class="topbar-subtitle">欢迎回来，智联控股 · 今日待办 3 项</span>
       </div>
@@ -78,7 +88,7 @@
       </div>
     </header>
     <div class="dashboard">
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebarNav" aria-label="会员中心导航">
         <h3>会员中心</h3>
         <a class="active" href="dashboard.html">会员信息展示</a>
         <a href="events.html">会议活动</a>
@@ -87,6 +97,7 @@
         <a href="performance.html">业绩提交</a>
         <a href="visits.html">访问记录</a>
       </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
       <div class="main-column">
         <main class="content-area">
           <section class="content-card member-overview" id="member">

--- a/events.html
+++ b/events.html
@@ -9,6 +9,16 @@
   <body>
     <header class="topbar">
       <div class="topbar-left">
+        <button
+          class="menu-toggle"
+          id="menuToggle"
+          type="button"
+          aria-label="展开菜单"
+          aria-controls="sidebarNav"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
         <span class="topbar-title">会议活动</span>
         <span class="topbar-subtitle">浏览即将开展的重点活动安排</span>
       </div>
@@ -78,7 +88,7 @@
       </div>
     </header>
     <div class="dashboard">
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebarNav" aria-label="会员中心导航">
         <h3>会员中心</h3>
         <a href="dashboard.html">会员信息展示</a>
         <a class="active" href="events.html">会议活动</a>
@@ -87,6 +97,7 @@
         <a href="performance.html">业绩提交</a>
         <a href="visits.html">访问记录</a>
       </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
       <div class="main-column">
         <main class="content-area">
           <section class="content-card" id="events">

--- a/performance.html
+++ b/performance.html
@@ -9,6 +9,16 @@
   <body>
     <header class="topbar">
       <div class="topbar-left">
+        <button
+          class="menu-toggle"
+          id="menuToggle"
+          type="button"
+          aria-label="展开菜单"
+          aria-controls="sidebarNav"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
         <span class="topbar-title">业绩提交</span>
         <span class="topbar-subtitle">沉淀案例成果，提升平台可信度</span>
       </div>
@@ -78,7 +88,7 @@
       </div>
     </header>
     <div class="dashboard">
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebarNav" aria-label="会员中心导航">
         <h3>会员中心</h3>
         <a href="dashboard.html">会员信息展示</a>
         <a href="events.html">会议活动</a>
@@ -87,6 +97,7 @@
         <a class="active" href="performance.html">业绩提交</a>
         <a href="visits.html">访问记录</a>
       </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
       <div class="main-column">
         <main class="content-area">
           <section class="content-card" id="performance">

--- a/products.html
+++ b/products.html
@@ -9,6 +9,16 @@
   <body>
     <header class="topbar">
       <div class="topbar-left">
+        <button
+          class="menu-toggle"
+          id="menuToggle"
+          type="button"
+          aria-label="展开菜单"
+          aria-controls="sidebarNav"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
         <span class="topbar-title">产品服务市场</span>
         <span class="topbar-subtitle">组合选型优秀供应商</span>
       </div>
@@ -78,7 +88,7 @@
       </div>
     </header>
     <div class="dashboard">
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebarNav" aria-label="会员中心导航">
         <h3>会员中心</h3>
         <a href="dashboard.html">会员信息展示</a>
         <a href="events.html">会议活动</a>
@@ -87,6 +97,7 @@
         <a href="performance.html">业绩提交</a>
         <a href="visits.html">访问记录</a>
       </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
       <div class="main-column">
         <main class="content-area">
           <section class="content-card" id="products">

--- a/resources.html
+++ b/resources.html
@@ -9,6 +9,16 @@
   <body>
     <header class="topbar">
       <div class="topbar-left">
+        <button
+          class="menu-toggle"
+          id="menuToggle"
+          type="button"
+          aria-label="展开菜单"
+          aria-controls="sidebarNav"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
         <span class="topbar-title">资源市场</span>
         <span class="topbar-subtitle">智能筛选优质渠道与合作资源</span>
       </div>
@@ -78,7 +88,7 @@
       </div>
     </header>
     <div class="dashboard">
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebarNav" aria-label="会员中心导航">
         <h3>会员中心</h3>
         <a href="dashboard.html">会员信息展示</a>
         <a href="events.html">会议活动</a>
@@ -87,6 +97,7 @@
         <a href="performance.html">业绩提交</a>
         <a href="visits.html">访问记录</a>
       </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
       <div class="main-column">
         <main class="content-area">
           <section class="content-card" id="resources">

--- a/visits.html
+++ b/visits.html
@@ -9,6 +9,16 @@
   <body>
     <header class="topbar">
       <div class="topbar-left">
+        <button
+          class="menu-toggle"
+          id="menuToggle"
+          type="button"
+          aria-label="展开菜单"
+          aria-controls="sidebarNav"
+          aria-expanded="false"
+        >
+          <span aria-hidden="true">☰</span>
+        </button>
         <span class="topbar-title">访问记录</span>
         <span class="topbar-subtitle">洞察团队访问行为，助力精准跟进</span>
       </div>
@@ -78,7 +88,7 @@
       </div>
     </header>
     <div class="dashboard">
-      <aside class="sidebar">
+      <aside class="sidebar" id="sidebarNav" aria-label="会员中心导航">
         <h3>会员中心</h3>
         <a href="dashboard.html">会员信息展示</a>
         <a href="events.html">会议活动</a>
@@ -87,6 +97,7 @@
         <a href="performance.html">业绩提交</a>
         <a class="active" href="visits.html">访问记录</a>
       </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" hidden></div>
       <div class="main-column">
         <main class="content-area">
           <section class="content-card" id="visits">


### PR DESCRIPTION
## Summary
- add a mobile sidebar toggle button and overlay across the member workspace pages
- update the responsive layout styles so the dashboard content renders comfortably on small screens
- enhance the dashboard script to manage the off-canvas navigation alongside the existing user menu dropdown

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da18a8c8dc8320bc0e9a251b0ab997