### PR TITLE
Fix topbar dropdown clipping

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -521,6 +521,7 @@ body.menu-open {
   right: 0;
   width: 100%;
   z-index: 40;
+  overflow: visible;
 }
 
 .topbar::after {
@@ -669,7 +670,7 @@ body.menu-open {
   padding: 8px 0;
   display: none;
   flex-direction: column;
-  z-index: 60;
+  z-index: 140;
 }
 
 .user-menu.active {
@@ -707,6 +708,7 @@ body.menu-open {
   display: none;
   flex-direction: column;
   gap: 16px;
+  z-index: 140;
 }
 
 .topbar-dropdown.active {


### PR DESCRIPTION
## Summary
- restore the landing header's overflow setting so its height and scroll behavior remain unchanged
- allow the sticky topbar to expose its dropdown panels without clipping the content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da320b63088320811d549d6fc74e44