### PR TITLE
Adjust founding team listing layout and ordering

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -410,6 +410,85 @@ nav {
   line-height: 1.7;
 }
 
+.founder-credits {
+  background: linear-gradient(180deg, #f6f8ff 0%, #eef2ff 100%);
+  color: #1d2240;
+  padding: 88px 64px;
+}
+
+.credits-container {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.credits-heading {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.credits-heading h2 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 0.04em;
+}
+
+.credits-heading p {
+  margin: 0;
+  color: #4b5170;
+  line-height: 1.8;
+}
+
+.credits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px 32px;
+}
+
+.credit-card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 20px 24px;
+  box-shadow: 0 16px 30px rgba(31, 36, 64, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.credit-name {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.credit-affiliation {
+  color: #5c6280;
+}
+
+@media (max-width: 768px) {
+  .founder-credits {
+    padding: 72px 32px;
+  }
+
+  .credits-grid {
+    gap: 20px 24px;
+  }
+}
+
+@media (max-width: 480px) {
+  .credits-heading h2 {
+    font-size: 1.7rem;
+  }
+
+  .credit-card {
+    padding: 18px 20px;
+  }
+}
+
 .footer {
   background: #130f40;
   color: rgba(255, 255, 255, 0.7);

--- a/index.html
+++ b/index.html
@@ -260,6 +260,73 @@
       </div>
     </section>
 
+    <section class="section scroll-reveal founder-credits" id="team">
+      <div class="credits-container">
+        <div class="credits-heading">
+          <h2>公司发起人清单</h2>
+          <p>公司发起人清单来自于天开班二期3组哪吒团队，团队成员如下：</p>
+        </div>
+        <div class="credits-grid" role="list">
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">陈力</span>
+            <span class="credit-affiliation">聚力文化</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">方晓琳</span>
+            <span class="credit-affiliation">怡云科技</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">郝缙</span>
+            <span class="credit-affiliation">国科雅智</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">何建军</span>
+            <span class="credit-affiliation">瀚阳科技</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">李兆华</span>
+            <span class="credit-affiliation">天开集团天津中心事业部</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">廖生梅</span>
+            <span class="credit-affiliation">福耀科技</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">刘金洲</span>
+            <span class="credit-affiliation">天开方圆</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">刘章浩</span>
+            <span class="credit-affiliation">天开集团科创服务</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">吴静怡</span>
+            <span class="credit-affiliation">华来科技</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">张伯千</span>
+            <span class="credit-affiliation">天银金租</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">张亮亮</span>
+            <span class="credit-affiliation">长河测控</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">张仕娟</span>
+            <span class="credit-affiliation">天开集团科创服务</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">张印朝</span>
+            <span class="credit-affiliation">迈勒新能源</span>
+          </div>
+          <div class="credit-card" role="listitem">
+            <span class="credit-name">赵刚强</span>
+            <span class="credit-affiliation">宏达科技</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <footer class="footer scroll-reveal">
       <div class="footer-grid">
         <div>


### PR DESCRIPTION
## Summary
- reorder the founding team names by pinyin initials and update the introductory copy per feedback
- replace the film-style credits roll with a multi-column card layout and softer visual treatment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db226a1bec8320b8964ccd80c67a0d