### PR TITLE
Add ICP filing notice across site footers

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -506,6 +506,32 @@ nav {
   margin-bottom: 12px;
 }
 
+.footer .icp-info {
+  margin-top: 24px;
+  justify-content: flex-start;
+}
+
+.icp-footer {
+  background: #130f40;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 24px 16px;
+  text-align: center;
+}
+
+.icp-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+}
+
+.icp-info a {
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: underline;
+}
+
 .main-content {
   max-width: 1200px;
   margin: 0 auto;

--- a/dashboard.html
+++ b/dashboard.html
@@ -171,6 +171,14 @@
         </main>
       </div>
     </div>
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="assets/dashboard.js"></script>
   </body>

--- a/events.html
+++ b/events.html
@@ -246,6 +246,15 @@
       </div>
     </div>
 
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
+
     <script src="assets/dashboard.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -349,6 +349,12 @@
         </div>
       </div>
       <p>© 2024 多多合作资源平台. All rights reserved.</p>
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
     </footer>
     <script>
       const scrollElements = document.querySelectorAll('.scroll-reveal');

--- a/login.html
+++ b/login.html
@@ -43,6 +43,14 @@
         </p>
       </div>
     </div>
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
     <script>
       const loginForm = document.getElementById('loginForm');
       if (loginForm) {

--- a/performance.html
+++ b/performance.html
@@ -155,6 +155,15 @@
       </div>
     </div>
 
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
+
     <script src="assets/dashboard.js"></script>
   </body>
 </html>

--- a/products.html
+++ b/products.html
@@ -243,6 +243,15 @@
       </div>
     </aside>
 
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
+
     <script src="assets/dashboard.js"></script>
   </body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -243,6 +243,15 @@
       </div>
     </aside>
 
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
+
     <script src="assets/dashboard.js"></script>
   </body>
 </html>

--- a/visits.html
+++ b/visits.html
@@ -165,6 +165,15 @@
       </div>
     </div>
 
+    <footer class="icp-footer">
+      <div class="icp-info">
+        <a href="http://beian.miit.gov.cn/" target="_blank" rel="noopener noreferrer"
+          >津ICP备2025039101号-1</a
+        >
+        <span>个人网站，展示经济管理学习心得用</span>
+      </div>
+    </footer>
+
     <script src="assets/dashboard.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add the ICP filing link and explanatory text to the footer of each public page
- create shared styling for the ICP notice so it displays consistently site-wide

## Testing
- Manual QA: opened `index.html` via `python -m http.server`


------
https://chatgpt.com/codex/tasks/task_e_68edd57f9b5c83208d53c5544d827b59